### PR TITLE
Re-enable linting in CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ python:
   - "3.8"
 cache: pip
 install:
-  - pip install pipenv 
+  - pip install pipenv
   - pipenv install --dev
 script:
-  # - pipenv run pylint discordbot shared
-  - pipenv run mypy --ignore-missing-imports --disallow-untyped-calls --disallow-incomplete-defs .
+  - pipenv run flake8 .
+  - pipenv run mypy .
 notifications:
     webhooks: https://www.travisbuddy.com/?insertMode=update
     on_success: never

--- a/Pipfile
+++ b/Pipfile
@@ -12,5 +12,6 @@ munch = "*"
 sentry-sdk = "*"
 
 [dev-packages]
-pylint = "*"
+flake8 = "*"
 mypy = "*"
+pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c4eaf6769f9449fb55396c2067203037461f8ca9c36c76a02db3650eb4b4c9d8"
+            "sha256": "8235de563c73914c9602d0875c09e468c362a20cf81b2beafd0d641e92ad628c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,7 @@
                 "sha256:ae55bac364c405caa23a4f2d6cfecc6a0daada500274ffca4a9230e7129eac59",
                 "sha256:b778ce0c909a2653741cb4b1ac7015b5c130ab9c897611df43ae6a58523cb965"
             ],
+            "markers": "python_full_version >= '3.5.3'",
             "version": "==3.6.2"
         },
         "async-timeout": {
@@ -38,6 +39,7 @@
                 "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
                 "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
             ],
+            "markers": "python_full_version >= '3.5.3'",
             "version": "==3.0.1"
         },
         "attrs": {
@@ -45,6 +47,7 @@
                 "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
                 "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.2.0"
         },
         "certifi": {
@@ -74,6 +77,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "multidict": {
@@ -96,6 +100,7 @@
                 "sha256:fcfbb44c59af3f8ea984de67ec7c306f618a3ec771c2843804069917a8f2e255",
                 "sha256:feed85993dbdb1dbc29102f50bca65bdc68f2c0c8d352468c25b54874f23c39d"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==4.7.6"
         },
         "munch": {
@@ -119,6 +124,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "urllib3": {
@@ -126,6 +132,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
         },
         "yarl": {
@@ -148,6 +155,7 @@
                 "sha256:e32f0fb443afcfe7f01f95172b66f279938fbc6bdaebe294b0ff6747fb6db020",
                 "sha256:fcbe419805c9b20db9a51d33b942feddbf6e7fb468cb20686fd7089d4164c12a"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.6.0"
         }
     },
@@ -157,13 +165,30 @@
                 "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
                 "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==2.4.2"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
+                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437",
+                "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"
+            ],
+            "version": "==1.0.1"
         },
         "isort": {
             "hashes": [
                 "sha256:6187a9f1ce8784cbc6d1b88790a43e6083a6302f03e9ae482acc0f232a98c843",
                 "sha256:c16eaa7432a1c004c585d79b12ad080c6c421dd18fe27982ca11f95e6898e432"
             ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==5.5.3"
         },
         "lazy-object-proxy": {
@@ -190,6 +215,7 @@
                 "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
                 "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.4.3"
         },
         "mccabe": {
@@ -198,6 +224,14 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
+                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==8.5.0"
         },
         "mypy": {
             "hashes": [
@@ -226,6 +260,30 @@
             ],
             "version": "==0.4.3"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.4"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.9.0"
+        },
         "pylint": {
             "hashes": [
                 "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210",
@@ -234,11 +292,28 @@
             "index": "pypi",
             "version": "==2.6.0"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40",
+                "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"
+            ],
+            "index": "pypi",
+            "version": "==6.0.2"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {

--- a/discordbot/main.py
+++ b/discordbot/main.py
@@ -8,17 +8,18 @@ from discord.message import Message
 from discord.reaction import Reaction
 from discord.user import User
 
-from shared import configuration
-from shared.limited_dict import LimitedSizeDict
-
 from . import warnings
 from .messagedata import MessageData
+from shared import configuration
+from shared.limited_dict import LimitedSizeDict
 
 
 class Bot(discord.Client):
     def __init__(self) -> None:
         super().__init__()
-        self.cache: Dict[Message, MessageData] = LimitedSizeDict(size_limit=1000)
+        self.cache: Dict[Message, MessageData] = LimitedSizeDict(
+            size_limit=1000,
+        )
 
     def init(self) -> None:
         self.run(configuration.get('token'))
@@ -32,7 +33,7 @@ class Bot(discord.Client):
         data.response_text = warnings.parse_message(message.content)
         if data.response_text is not None:
             try:
-                await message.add_reaction("🙊")
+                await message.add_reaction('🙊')
                 self.cache[message] = data
             except Forbidden:
                 pass
@@ -54,7 +55,7 @@ class Bot(discord.Client):
         data.response_text = warnings.parse_message(after.content)
         prev_reacted = [r for r in after.reactions if r.me]
         if data.response_text is None and prev_reacted:
-            await after.remove_reaction("🙊", self.user)
+            await after.remove_reaction('🙊', self.user)
             if data.response_message is not None:
                 await data.response_message.delete()
 
@@ -63,28 +64,45 @@ class Bot(discord.Client):
         if reaction.me:
             c = c - 1
         if reaction.message.author == self.user:
-            if c > 0 and not reaction.custom_emoji and reaction.emoji == "❎":
+            if c > 0 and not reaction.custom_emoji and reaction.emoji == '❎':
                 await reaction.message.delete()
-        elif c > 0 and reaction.emoji == "🙊":
+        elif c > 0 and reaction.emoji == '🙊':
             data = self.cache.get(reaction.message, None)
             if data is None:
                 return
             if data.response_message is None and data.response_text is not None:
-                data.response_message = await reaction.message.channel.send(data.response_text)
-                await data.response_message.add_reaction("❎")
+                data.response_message = await reaction.message.channel.send(
+                    data.response_text,
+                )
+                await data.response_message.add_reaction('❎')
 
     async def on_server_join(self, server: Guild) -> None:
-        await server.default_channel.send(":see_no_evil: :hear_no_evil: :speak_no_evil:")
-        await server.default_channel.send("If I react to a message, click on that reaction to see more details.")
+        await server.default_channel.send(
+            ':see_no_evil: :hear_no_evil: :speak_no_evil:',
+        )
+        await server.default_channel.send(
+            'If I react to a message, click on that reaction to see more details.',
+        )
 
     async def on_ready(self) -> None:
-        print('Logged in as {username} ({id})'.format(username=self.user.name, id=self.user.id))
-        print('Connected to {0}'.format(', '.join([server.name for server in self.guilds])))
+        print(
+            'Logged in as {username} ({id})'.format(
+                username=self.user.name,
+                id=self.user.id,
+            ),
+        )
+        print(
+            'Connected to {}'.format(
+                ', '.join([server.name for server in self.guilds]),
+            ),
+        )
         print('--------')
+
 
 def init() -> None:
     client = Bot()
     client.init()
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     init()

--- a/discordbot/messagedata.py
+++ b/discordbot/messagedata.py
@@ -3,7 +3,8 @@ from typing import Optional
 from discord import Message
 from munch import Munch
 
-__all__ = ('MessageData')
+__all__ = 'MessageData'
+
 
 class MessageData(Munch):
     def __init__(self) -> None:

--- a/discordbot/warnings.py
+++ b/discordbot/warnings.py
@@ -49,15 +49,18 @@ WARNINGS = {
     r'\b(psycho|schitzo|schizo|spaz|derp|spastic|spacker)\b': 'ableist language. check out some alternatives! <http://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html> (scroll down)',
 }
 
+GUYS_RESPONSE = """Many people feel excluded when you refer to a group of people as "Guys".
+Some alternatives if you meant to refer to explicitly men: men, dudes
+Some alternatives if you meant to refer to people in general: all, everyone, friends, folks, people"""
+
 
 def parse_message(text: str) -> Optional[str]:
     for key in WARNINGS:
         m = re.search(key, text, re.IGNORECASE)
         if m:
-            return 'gentle reminder: {0} is {1}'.format(m.group(0), WARNINGS[key])
+            return 'gentle reminder: {} is {}'.format(m.group(0), WARNINGS[key])
 
     if re.search(r'\b(hey|hi|you)\W+(guys)\b', text, re.IGNORECASE):
-        return """Many people feel excluded when you refer to a group of people as "Guys".
-Some alternatives if you meant to refer to explicitly men: men, dudes
-Some alternatives if you meant to refer to people in general: all, everyone, friends, folks, people"""
+        return GUYS_RESPONSE
+
     return None

--- a/run.py
+++ b/run.py
@@ -1,5 +1,6 @@
-from discordbot import main
 import sentry_sdk
 
-sentry_sdk.init("https://83766626d7a64c1084fd140390175ea5@sentry.io/1757452")
+from discordbot import main
+
+sentry_sdk.init('https://83766626d7a64c1084fd140390175ea5@sentry.io/1757452')
 main.init()

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit 1
 git pull
 pipenv install
 pipenv run python run.py

--- a/shared/configuration.py
+++ b/shared/configuration.py
@@ -1,14 +1,13 @@
 import inspect
 import json
 import os
-import random
-import string
 
 from .exceptions import InvalidArgumentException
 
 DEFAULTS = {
-    "token": "",
+    'token': '',
 }
+
 
 def get(key: str) -> str:
     try:
@@ -23,15 +22,20 @@ def get(key: str) -> str:
         # Lock in the default value if we use it.
         cfg[key] = DEFAULTS[key]
 
-        if inspect.isfunction(cfg[key]): # If default value is a function, call it.
+        if inspect.isfunction(cfg[key]):  # If default value is a function, call it.
             cfg[key] = cfg[key]()
     else:
-        raise InvalidArgumentException('No default or other configuration value available for {key}'.format(key=key))
+        raise InvalidArgumentException(
+            'No default or other configuration value available for {key}'.format(
+                key=key,
+            ),
+        )
 
-    print("CONFIG: {0}={1}".format(key, cfg[key]))
+    print('CONFIG: {}={}'.format(key, cfg[key]))
     fh = open('config.json', 'w')
     fh.write(json.dumps(cfg, indent=4))
     return cfg[key]
+
 
 def write(key: str, value: str) -> str:
     try:
@@ -41,7 +45,7 @@ def write(key: str, value: str) -> str:
 
     cfg[key] = value
 
-    print("CONFIG: {0}={1}".format(key, cfg[key]))
+    print('CONFIG: {}={}'.format(key, cfg[key]))
     fh = open('config.json', 'w')
     fh.write(json.dumps(cfg, indent=4, sort_keys=True))
     return cfg[key]

--- a/shared/configuration.py
+++ b/shared/configuration.py
@@ -1,6 +1,8 @@
 import inspect
 import json
 import os
+from typing import Any
+from typing import Dict
 
 from .exceptions import InvalidArgumentException
 
@@ -8,12 +10,24 @@ DEFAULTS = {
     'token': '',
 }
 
+CONFIG_FILE = 'config.json'
+
+
+def _load() -> Dict[str, Any]:
+    try:
+        with open(CONFIG_FILE) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def _dump(cfg: Dict[str, Any]) -> None:
+    with open(CONFIG_FILE, 'w') as f:
+        json.dump(cfg, f, indent=4)
+
 
 def get(key: str) -> str:
-    try:
-        cfg = json.load(open('config.json'))
-    except FileNotFoundError:
-        cfg = {}
+    cfg = _load()
     if key in cfg:
         return cfg[key]
     elif key in os.environ:
@@ -22,30 +36,24 @@ def get(key: str) -> str:
         # Lock in the default value if we use it.
         cfg[key] = DEFAULTS[key]
 
-        if inspect.isfunction(cfg[key]):  # If default value is a function, call it.
+        # If default value is a function, call it.
+        if inspect.isfunction(cfg[key]):
             cfg[key] = cfg[key]()
     else:
         raise InvalidArgumentException(
-            'No default or other configuration value available for {key}'.format(
-                key=key,
-            ),
+            f'No default or other configuration value available for {key}',
         )
 
     print('CONFIG: {}={}'.format(key, cfg[key]))
-    fh = open('config.json', 'w')
-    fh.write(json.dumps(cfg, indent=4))
+    _dump(cfg)
     return cfg[key]
 
 
 def write(key: str, value: str) -> str:
-    try:
-        cfg = json.load(open('config.json'))
-    except FileNotFoundError:
-        cfg = {}
+    cfg = _load()
 
     cfg[key] = value
 
     print('CONFIG: {}={}'.format(key, cfg[key]))
-    fh = open('config.json', 'w')
-    fh.write(json.dumps(cfg, indent=4, sort_keys=True))
+    _dump(cfg)
     return cfg[key]

--- a/shared/container.py
+++ b/shared/container.py
@@ -1,9 +1,9 @@
 from munch import Munch
 
 
-# pylint: disable=too-many-instance-attributes
 class Container(Munch):
-    # Reverse the order of operations from Munch because it gives us a speedup when we access hundreds of thousands of properties in a request.
+    # Reverse the order of operations from Munch because it gives us a speedup
+    # when we access hundreds of thousands of properties in a request.
     def __getattr__(self, k):
         try:
             return self[k]

--- a/shared/exceptions.py
+++ b/shared/exceptions.py
@@ -1,29 +1,38 @@
 class PDException(Exception):
     pass
 
+
 class OperationalException(PDException):
     pass
+
 
 class ParseException(PDException):
     pass
 
+
 class InvalidDataException(PDException):
     pass
+
 
 class DatabaseException(PDException):
     pass
 
+
 class DoesNotExistException(PDException):
     pass
+
 
 class TooManyItemsException(PDException):
     pass
 
+
 class TooFewItemsException(PDException):
     pass
 
+
 class InvalidArgumentException(PDException):
     pass
+
 
 class LockNotAcquiredException(DatabaseException):
     pass

--- a/shared/limited_dict.py
+++ b/shared/limited_dict.py
@@ -4,16 +4,16 @@ from typing import Any
 
 # https://stackoverflow.com/a/2437645
 class LimitedSizeDict(OrderedDict):
-  def __init__(self, *args: Any, **kwds: Any) -> None:
-    self.size_limit = kwds.pop("size_limit", None)
-    OrderedDict.__init__(self, *args, **kwds)
-    self._check_size_limit()
+    def __init__(self, *args: Any, **kwds: Any) -> None:
+        self.size_limit = kwds.pop('size_limit', None)
+        OrderedDict.__init__(self, *args, **kwds)
+        self._check_size_limit()
 
-  def __setitem__(self, key, value):
-    OrderedDict.__setitem__(self, key, value)
-    self._check_size_limit()
+    def __setitem__(self, key, value):
+        OrderedDict.__setitem__(self, key, value)
+        self._check_size_limit()
 
-  def _check_size_limit(self) -> None:
-    if self.size_limit is not None:
-      while len(self) > self.size_limit:
-        self.popitem(last=False)
+    def _check_size_limit(self) -> None:
+        if self.size_limit is not None:
+            while len(self) > self.size_limit:
+                self.popitem(last=False)


### PR DESCRIPTION
Hi there! I'm messing around with izawaru_bot (and hoping to add a feature or two for a server that uses it). As I was poking around I realized that linting had been commented out in the .travel.yml and had backtracked a bit. I figured my first change could help ameliorate that situation.

I've re-enabled linting in the travis config and moved some things around to make it easier to iterate locally. I also swapped out pylint for flake8 as I'm more familiar with it and prefer its style of # noqa to pylints configuration. Happy to swap back if you prefer pylint strongly.

Changes I made:
* A one-off run of `pyupgrade` and `autopep8` to automate some of the fixes.
* Turned off E501 / line length warning to account for the `warnings.py` dictionary.
* The other changes I've made _should_ just be style fixes so that I could reenable linting in CI.